### PR TITLE
Update Python image version to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official Python runtime as base image
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -37,3 +37,4 @@ EXPOSE 5002
 
 # Use Gunicorn to serve the application
 CMD ["gunicorn", "--workers", "2", "--bind", "0.0.0.0:5002", "--access-logfile", "-", "--error-logfile", "-", "episeerr:app"]
+


### PR DESCRIPTION
The image `python:3.11-slim` being used for Episeerr as base image does contain 2 critical security issues:
<img width="220" height="68" alt="image" src="https://github.com/user-attachments/assets/ba509b16-f141-472c-bdbb-920e2dd2d705" />

For the medium vulnerability is no patch currently available.

See: https://hub.docker.com/layers/library/python/3.11-slim/images/sha256-959bb05733de4910ec843519526290fea947d8aa1a6f1ca06aee870d1e9a664d


From my local testings, I could not spot any issues using `python:3.13-slim`