### PR TITLE
Fixed leading and trailing whitespaces and dashes in app URLs

### DIFF
--- a/episeerr.py
+++ b/episeerr.py
@@ -26,14 +26,24 @@ app = Flask(__name__)
 load_dotenv()
 BASE_DIR = os.getcwd()
 
+# Remove leading and trailing whitespaces and trailing / from .env URLs if present
+# Otherwise URLs will look like url:port//series/name-of-series
+def normalize_url(url):
+    if url is None:
+        return None
+    cleaned_url = url.strip()
+    if cleaned_url.endswith('/') and cleaned_url != '/':
+        cleaned_url = cleaned_url[:-1]
+    return cleaned_url
+
 # Sonarr variables
-SONARR_URL = os.getenv('SONARR_URL')
+SONARR_URL = normalize_url(os.getenv('SONARR_URL'))
 SONARR_API_KEY = os.getenv('SONARR_API_KEY')
 
 # Jellyseerr/Overseerr variables
-JELLYSEERR_URL = os.getenv('JELLYSEERR_URL', '')
+JELLYSEERR_URL = normalize_url(os.getenv('JELLYSEERR_URL', ''))
 JELLYSEERR_API_KEY = os.getenv('JELLYSEERR_API_KEY')
-OVERSEERR_URL = os.getenv('OVERSEERR_URL')
+OVERSEERR_URL = normalize_url(os.getenv('OVERSEERR_URL'))
 OVERSEERR_API_KEY = os.getenv('OVERSEERR_API_KEY')
 SEERR_ENABLED = bool((JELLYSEERR_URL and JELLYSEERR_API_KEY) or (OVERSEERR_URL and OVERSEERR_API_KEY))
 

--- a/media_processor.py
+++ b/media_processor.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 import threading
 import subprocess
 
+from episeerr import normalize_url
+
 
 # Add these imports at the top if missing
 LAST_PROCESSED_JELLYFIN_EPISODES = {}
@@ -238,7 +240,7 @@ def get_activity_date_with_hierarchy(series_id, series_title=None, return_comple
     # Step 2: Check external services (only if title available)
     if series_title:
         # Check which external service is configured (user typically has one, not both)
-        tautulli_url = os.getenv('TAUTULLI_URL')
+        tautulli_url = normalize_url(os.getenv('TAUTULLI_URL'))
         tautulli_api_key = os.getenv('TAUTULLI_API_KEY')
         jellyfin_url = os.getenv('JELLYFIN_URL')
         jellyfin_api_key = os.getenv('JELLYFIN_API_KEY')
@@ -555,7 +557,7 @@ def get_tautulli_last_watched(series_title, return_complete=False):
                         If False, returns just timestamp (existing behavior)
     """
     try:
-        tautulli_url = os.getenv('TAUTULLI_URL')
+        tautulli_url = normalize_url(os.getenv('TAUTULLI_URL'))
         tautulli_api_key = os.getenv('TAUTULLI_API_KEY')
         
         if not tautulli_url or not tautulli_api_key:


### PR DESCRIPTION
Heya,

Users will enter the URLs in the .env file with or without ending /. No matter what is stated in the documentation :)

This will lead to the situation, that the URLs which will be generated to link a series to Sonarr, will look like 

http://url:port//series/series-name which will fail to open correctly. 

This PR takes care of this issue and removes leading and trailing whitespaces and / if present.