### PR TITLE
Add periodic missing-episode backfill so caught-up airing shows stay current

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,11 +1020,14 @@ The missing episode backfill closes that gap: on a schedule (default: every 4 ho
 - Monitored
 - Missing (no file)
 - Already aired (at least 30 minutes ago)
+- Recent — aired within the max-age window (default: last 7 days)
 
 **Notes:**
 - Only applies to rules with action **search** — for *monitor* rules, episodes stay monitored-only by design.
-- Configure the interval in Scheduler Admin → "Missing Episode Backfill (hours)" (`missing_backfill_hours` in global settings; `0` disables it). The `MISSING_BACKFILL_HOURS` env var sets the default.
-- Future episodes are never searched, so the delay-profile hold that prevents unwanted full-season grabs stays intact.
+- Configure in Scheduler Admin → "Missing Episode Backfill (hours)" (`missing_backfill_hours` in global settings; `0` disables it) and "Backfill Max Age (days)" (`missing_backfill_max_age_days`; `0` removes the cap). The `MISSING_BACKFILL_HOURS` / `MISSING_BACKFILL_MAX_AGE_DAYS` env vars set the defaults.
+- The max-age cap is what keeps the backfill scoped to *newly aired* episodes: episodes whose files Episeerr's own cleanup deleted (cleanup leaves them monitored), or the aired back catalog of a fully-monitored series added to a rule, are older than the window and are **not** re-searched.
+- Future episodes are never searched, so adding a series to a rule still doesn't grab upcoming seasons; note the backfill *does* intentionally bypass the delay-profile hold for recent aired episodes — that is the point.
+- The backfill ignores **Global Dry Run Mode**: dry run gates *deletions*, while the backfill only triggers searches (it never deletes anything). Set the interval to `0` to disable it instead.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,24 @@ Watch E5 → Get E6, E7 → Keep E5 → Delete E1-E4
 
 ---
 
+### 🔎 Missing Episode Backfill
+
+**Weekly shows stay current even when you're caught up.**
+
+Episeerr holds automatic (RSS) grabs for managed series with a Sonarr delay profile, and normally relies on watch-event searches to grab episodes. But if you're fully caught up on an airing show, no watch event fires when a new episode airs — so it would never download.
+
+The missing episode backfill closes that gap: on a schedule (default: every 4 hours) it checks every series assigned to a rule and triggers a Sonarr search for episodes that are:
+- Monitored
+- Missing (no file)
+- Already aired (at least 30 minutes ago)
+
+**Notes:**
+- Only applies to rules with action **search** — for *monitor* rules, episodes stay monitored-only by design.
+- Configure the interval in Scheduler Admin → "Missing Episode Backfill (hours)" (`missing_backfill_hours` in global settings; `0` disables it). The `MISSING_BACKFILL_HOURS` env var sets the default.
+- Future episodes are never searched, so the delay-profile hold that prevents unwanted full-season grabs stays intact.
+
+---
+
 ### 💾 Storage Management
 
 **Automatic cleanup based on time and viewing activity.**

--- a/episeerr.py
+++ b/episeerr.py
@@ -1119,13 +1119,19 @@ class OCDarrScheduler:
         except ValueError:
             default_backfill_hours = 4.0
         try:
+            default_backfill_max_age_days = float(os.getenv('MISSING_BACKFILL_MAX_AGE_DAYS', '7'))
+        except ValueError:
+            default_backfill_max_age_days = 7.0
+        try:
             import media_processor
             global_settings = media_processor.load_global_settings()
             self.cleanup_interval_hours = global_settings.get('cleanup_interval_hours', 6)
             self.missing_backfill_hours = float(global_settings.get('missing_backfill_hours', default_backfill_hours))
+            self.missing_backfill_max_age_days = float(global_settings.get('missing_backfill_max_age_days', default_backfill_max_age_days))
         except:
             self.cleanup_interval_hours = 6  # Fallback
             self.missing_backfill_hours = default_backfill_hours
+            self.missing_backfill_max_age_days = default_backfill_max_age_days
     
     def start_scheduler(self):
         if self.running:
@@ -1217,6 +1223,7 @@ class OCDarrScheduler:
             "type": "global_storage_gate",
             "interval_hours": self.cleanup_interval_hours,
             "missing_backfill_hours": self.missing_backfill_hours,
+            "missing_backfill_max_age_days": self.missing_backfill_max_age_days,
             "last_missing_backfill": datetime.fromtimestamp(self.last_missing_backfill).strftime("%Y-%m-%d %H:%M:%S") if self.last_missing_backfill else "Never",
             "last_cleanup": datetime.fromtimestamp(self.last_cleanup).strftime("%Y-%m-%d %H:%M:%S") if self.last_cleanup else "Never",
             "next_cleanup": next_cleanup
@@ -4478,8 +4485,9 @@ def update_global_settings():
         cleanup_interval_hours = data.get('cleanup_interval_hours', 6)
         dry_run_mode = data.get('dry_run_mode', False)
         auto_assign_new_series = data.get('auto_assign_new_series', False)
-        # Preserve the current value if the client did not send the field
+        # Preserve the current values if the client did not send the fields
         missing_backfill_hours = data.get('missing_backfill_hours', current_settings.get('missing_backfill_hours', 4))
+        missing_backfill_max_age_days = data.get('missing_backfill_max_age_days', current_settings.get('missing_backfill_max_age_days', 7))
         
         
         # NEW: Notification settings
@@ -4496,6 +4504,7 @@ def update_global_settings():
             'global_storage_min_gb': storage_min_gb,
             'cleanup_interval_hours': int(cleanup_interval_hours),
             'missing_backfill_hours': float(missing_backfill_hours) if missing_backfill_hours is not None else 4,
+            'missing_backfill_max_age_days': float(missing_backfill_max_age_days) if missing_backfill_max_age_days is not None else 7,
             'dry_run_mode': bool(dry_run_mode),
             'auto_assign_new_series': bool(auto_assign_new_series),
 

--- a/episeerr.py
+++ b/episeerr.py
@@ -1109,16 +1109,23 @@ class OCDarrScheduler:
         self.running = False
         self.last_cleanup = 0
         self.last_aired_check = 0
+        self.last_missing_backfill = 0
         self.update_interval_from_settings()
-    
+
     def update_interval_from_settings(self):
         """Update cleanup interval from global settings."""
+        try:
+            default_backfill_hours = float(os.getenv('MISSING_BACKFILL_HOURS', '4'))
+        except ValueError:
+            default_backfill_hours = 4.0
         try:
             import media_processor
             global_settings = media_processor.load_global_settings()
             self.cleanup_interval_hours = global_settings.get('cleanup_interval_hours', 6)
+            self.missing_backfill_hours = float(global_settings.get('missing_backfill_hours', default_backfill_hours))
         except:
             self.cleanup_interval_hours = 6  # Fallback
+            self.missing_backfill_hours = default_backfill_hours
     
     def start_scheduler(self):
         if self.running:
@@ -1151,6 +1158,19 @@ class OCDarrScheduler:
                     except Exception as aired_err:
                         print(f"Aired not downloaded check error: {aired_err}")
                     self.last_aired_check = current_time
+
+                # Missing-episode backfill: the episeerr delay profile blocks
+                # Sonarr's automatic (RSS) grabs for managed series, so newly
+                # aired episodes of caught-up shows need a periodic search.
+                if self.missing_backfill_hours > 0:
+                    hours_since_backfill = (current_time - self.last_missing_backfill) / 3600
+                    if hours_since_backfill >= self.missing_backfill_hours:
+                        print("🔎 Starting scheduled missing episode backfill...")
+                        try:
+                            episeerr_utils.run_missing_episode_backfill()
+                        except Exception as backfill_err:
+                            print(f"Missing episode backfill error: {backfill_err}")
+                        self.last_missing_backfill = current_time
 
                 time.sleep(600)  # Check every 10 minutes
             except Exception as e:
@@ -1196,6 +1216,8 @@ class OCDarrScheduler:
             "status": "running",
             "type": "global_storage_gate",
             "interval_hours": self.cleanup_interval_hours,
+            "missing_backfill_hours": self.missing_backfill_hours,
+            "last_missing_backfill": datetime.fromtimestamp(self.last_missing_backfill).strftime("%Y-%m-%d %H:%M:%S") if self.last_missing_backfill else "Never",
             "last_cleanup": datetime.fromtimestamp(self.last_cleanup).strftime("%Y-%m-%d %H:%M:%S") if self.last_cleanup else "Never",
             "next_cleanup": next_cleanup
         }
@@ -4451,10 +4473,13 @@ def update_global_settings():
         import media_processor
         
         data = request.json
+        current_settings = media_processor.load_global_settings()
         storage_min_gb = data.get('global_storage_min_gb')
         cleanup_interval_hours = data.get('cleanup_interval_hours', 6)
         dry_run_mode = data.get('dry_run_mode', False)
         auto_assign_new_series = data.get('auto_assign_new_series', False)
+        # Preserve the current value if the client did not send the field
+        missing_backfill_hours = data.get('missing_backfill_hours', current_settings.get('missing_backfill_hours', 4))
         
         
         # NEW: Notification settings
@@ -4470,6 +4495,7 @@ def update_global_settings():
         settings = {
             'global_storage_min_gb': storage_min_gb,
             'cleanup_interval_hours': int(cleanup_interval_hours),
+            'missing_backfill_hours': float(missing_backfill_hours) if missing_backfill_hours is not None else 4,
             'dry_run_mode': bool(dry_run_mode),
             'auto_assign_new_series': bool(auto_assign_new_series),
 

--- a/episeerr_utils.py
+++ b/episeerr_utils.py
@@ -1011,24 +1011,35 @@ def search_episodes(series_id, episode_ids, headers):
 # no file, and have already aired.
 
 MISSING_BACKFILL_AIR_BUFFER_MINUTES = 30
+MISSING_BACKFILL_MAX_AGE_DAYS = 7
 
-def select_missing_aired_episodes(episodes, buffer_minutes=MISSING_BACKFILL_AIR_BUFFER_MINUTES, now_utc=None):
+def select_missing_aired_episodes(episodes, buffer_minutes=MISSING_BACKFILL_AIR_BUFFER_MINUTES,
+                                  max_age_days=MISSING_BACKFILL_MAX_AGE_DAYS, now_utc=None):
     """Select episodes eligible for the missing-episode backfill.
 
     An episode qualifies when it is monitored, has no file, and its
     airDateUtc is at least ``buffer_minutes`` in the past (small buffer so we
-    do not search for an episode seconds after it airs).
+    do not search for an episode seconds after it airs) but no more than
+    ``max_age_days`` old. The recency cap keeps the backfill scoped to
+    "newly aired episodes of shows you are current on": without it, episodes
+    whose files Episeerr's own cleanup deleted (cleanup deletes files but
+    leaves episodes monitored) or a fully-monitored back catalog would be
+    re-searched forever.
 
     :param episodes: List of Sonarr episode dicts
     :param buffer_minutes: Minimum minutes since airDateUtc
-    :param now_utc: Override "now" (naive UTC datetime) for testing
+    :param max_age_days: Maximum days since airDateUtc (0 disables the cap)
+    :param now_utc: Override "now" (datetime, naive treated as UTC) for testing
     :return: List of qualifying episode dicts
     """
-    from datetime import timedelta
+    from datetime import timedelta, timezone
 
     if now_utc is None:
-        now_utc = datetime.utcnow()
+        now_utc = datetime.now(timezone.utc)
+    elif now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=timezone.utc)
     cutoff = now_utc - timedelta(minutes=buffer_minutes)
+    oldest = now_utc - timedelta(days=max_age_days) if max_age_days and max_age_days > 0 else None
 
     selected = []
     for ep in episodes:
@@ -1040,12 +1051,15 @@ def select_missing_aired_episodes(episodes, buffer_minutes=MISSING_BACKFILL_AIR_
         if not air_date_str:
             continue  # unaired / TBA episodes have no airDateUtc
         try:
-            air_date = datetime.fromisoformat(air_date_str.replace('Z', '+00:00')).replace(tzinfo=None)
+            air_date = datetime.fromisoformat(air_date_str.replace('Z', '+00:00')).astimezone(timezone.utc)
         except (ValueError, TypeError):
             logger.warning(f"Backfill: could not parse airDateUtc '{air_date_str}' for episode {ep.get('id')}")
             continue
-        if air_date <= cutoff:
-            selected.append(ep)
+        if air_date > cutoff:
+            continue  # not aired yet (or within the post-air buffer)
+        if oldest is not None and air_date < oldest:
+            continue  # older than the backfill window - not a "stay current" gap
+        selected.append(ep)
     return selected
 
 
@@ -1067,6 +1081,17 @@ def run_missing_episode_backfill():
     if not SONARR_URL or not SONARR_API_KEY:
         logger.warning("Backfill: Sonarr not configured, skipping")
         return
+
+    try:
+        default_max_age_days = float(os.getenv('MISSING_BACKFILL_MAX_AGE_DAYS', str(MISSING_BACKFILL_MAX_AGE_DAYS)))
+    except ValueError:
+        default_max_age_days = float(MISSING_BACKFILL_MAX_AGE_DAYS)
+    try:
+        global_settings = media_processor.load_global_settings()
+        max_age_days = float(global_settings.get('missing_backfill_max_age_days', default_max_age_days))
+    except Exception as e:
+        logger.warning(f"Backfill: could not load global settings ({e}), using {default_max_age_days}-day age cap")
+        max_age_days = default_max_age_days
 
     headers = get_sonarr_headers()
     total_series = 0
@@ -1095,7 +1120,7 @@ def run_missing_episode_backfill():
                     logger.warning(f"Backfill: failed to get episodes for series {sid} (status {resp.status_code}), skipping")
                     continue
 
-                missing = select_missing_aired_episodes(resp.json())
+                missing = select_missing_aired_episodes(resp.json(), max_age_days=max_age_days)
                 if not missing:
                     continue
 

--- a/episeerr_utils.py
+++ b/episeerr_utils.py
@@ -1000,6 +1000,134 @@ def search_episodes(series_id, episode_ids, headers):
         logger.error(f"Error searching for episodes: {str(e)}", exc_info=True)
         return False
 
+# ============================================================
+# MISSING EPISODE BACKFILL
+# ============================================================
+# Episeerr holds automatic (RSS) grabs for managed series via a Sonarr delay
+# profile bound to the episeerr tags. EpisodeSearch commands bypass the delay
+# profile, but they only fire on watch events - so a user who is caught up on
+# a currently-airing show never receives newly aired episodes. This periodic
+# backfill closes that gap: it searches for episodes that are monitored, have
+# no file, and have already aired.
+
+MISSING_BACKFILL_AIR_BUFFER_MINUTES = 30
+
+def select_missing_aired_episodes(episodes, buffer_minutes=MISSING_BACKFILL_AIR_BUFFER_MINUTES, now_utc=None):
+    """Select episodes eligible for the missing-episode backfill.
+
+    An episode qualifies when it is monitored, has no file, and its
+    airDateUtc is at least ``buffer_minutes`` in the past (small buffer so we
+    do not search for an episode seconds after it airs).
+
+    :param episodes: List of Sonarr episode dicts
+    :param buffer_minutes: Minimum minutes since airDateUtc
+    :param now_utc: Override "now" (naive UTC datetime) for testing
+    :return: List of qualifying episode dicts
+    """
+    from datetime import timedelta
+
+    if now_utc is None:
+        now_utc = datetime.utcnow()
+    cutoff = now_utc - timedelta(minutes=buffer_minutes)
+
+    selected = []
+    for ep in episodes:
+        if not ep.get('monitored', False):
+            continue
+        if ep.get('hasFile', False):
+            continue
+        air_date_str = ep.get('airDateUtc')
+        if not air_date_str:
+            continue  # unaired / TBA episodes have no airDateUtc
+        try:
+            air_date = datetime.fromisoformat(air_date_str.replace('Z', '+00:00')).replace(tzinfo=None)
+        except (ValueError, TypeError):
+            logger.warning(f"Backfill: could not parse airDateUtc '{air_date_str}' for episode {ep.get('id')}")
+            continue
+        if air_date <= cutoff:
+            selected.append(ep)
+    return selected
+
+
+def run_missing_episode_backfill():
+    """Search Sonarr for monitored, missing, already-aired episodes of rule-managed series.
+
+    Only series assigned to rules with action_option 'search' are searched -
+    for 'monitor' rules the user explicitly chose not to auto-search.
+    Never raises: any failure is logged and skipped so the scheduler thread
+    stays alive.
+    """
+    try:
+        import media_processor  # lazy import (media_processor imports this module)
+        config = media_processor.load_config()
+    except Exception as e:
+        logger.error(f"Backfill: could not load config: {e}")
+        return
+
+    if not SONARR_URL or not SONARR_API_KEY:
+        logger.warning("Backfill: Sonarr not configured, skipping")
+        return
+
+    headers = get_sonarr_headers()
+    total_series = 0
+    total_searched = 0
+
+    for rule_name, rule in config.get('rules', {}).items():
+        series_map = rule.get('series', {}) or {}
+        if not series_map:
+            continue
+        action_option = rule.get('action_option', 'monitor')
+        if action_option != 'search':
+            logger.info(f"⏭️ Backfill: rule '{rule_name}' action is '{action_option}' - not searching its {len(series_map)} series")
+            continue
+
+        for series_id in series_map:
+            total_series += 1
+            try:
+                sid = int(series_id)
+                resp = http.get(
+                    f"{SONARR_URL}/api/v3/episode",
+                    headers=headers,
+                    params={'seriesId': sid},
+                    timeout=30
+                )
+                if not resp.ok:
+                    logger.warning(f"Backfill: failed to get episodes for series {sid} (status {resp.status_code}), skipping")
+                    continue
+
+                missing = select_missing_aired_episodes(resp.json())
+                if not missing:
+                    continue
+
+                series_title = f"series {sid}"
+                try:
+                    series_resp = http.get(f"{SONARR_URL}/api/v3/series/{sid}", headers=headers, timeout=30)
+                    if series_resp.ok:
+                        series_title = series_resp.json().get('title', series_title)
+                except Exception:
+                    pass
+
+                episode_ids = [ep['id'] for ep in missing]
+                ep_labels = ', '.join(
+                    f"S{ep.get('seasonNumber', 0):02d}E{ep.get('episodeNumber', 0):02d}" for ep in missing
+                )
+                logger.info(f"🔎 Backfill: '{series_title}' (rule '{rule_name}') has {len(missing)} aired monitored episode(s) without a file: {ep_labels}")
+
+                if search_episodes(sid, episode_ids, headers):
+                    total_searched += len(episode_ids)
+                    logger.info(f"✓ Backfill: triggered search for {len(episode_ids)} episode(s) of '{series_title}'")
+                else:
+                    logger.warning(f"Backfill: search command failed for '{series_title}'")
+            except Exception as e:
+                logger.error(f"Backfill: error processing series {series_id}: {e}")
+                continue
+
+    if total_searched:
+        logger.info(f"✅ Missing episode backfill complete: searched {total_searched} episode(s) across {total_series} managed series")
+    else:
+        logger.info(f"✓ Missing episode backfill complete: nothing to search ({total_series} managed series checked)")
+
+
 def get_series_episodes(series_id, season_number, headers):
     """
     Get all episodes for a specific series and season.

--- a/media_processor.py
+++ b/media_processor.py
@@ -1510,6 +1510,7 @@ def load_global_settings():
                 'global_storage_min_gb': None,
                 'cleanup_interval_hours': 6,
                 'missing_backfill_hours': 4,
+                'missing_backfill_max_age_days': 7,
                 'dry_run_mode': True,
                 'auto_assign_new_series': False,
                 
@@ -1525,6 +1526,7 @@ def load_global_settings():
             'global_storage_min_gb': None,
             'cleanup_interval_hours': 6,
             'missing_backfill_hours': 4,
+            'missing_backfill_max_age_days': 7,
             'dry_run_mode': True,
             'auto_assign_new_series': False,
             'notifications_enabled': False,

--- a/media_processor.py
+++ b/media_processor.py
@@ -1509,6 +1509,7 @@ def load_global_settings():
             default_settings = {
                 'global_storage_min_gb': None,
                 'cleanup_interval_hours': 6,
+                'missing_backfill_hours': 4,
                 'dry_run_mode': True,
                 'auto_assign_new_series': False,
                 
@@ -1523,6 +1524,7 @@ def load_global_settings():
         return {
             'global_storage_min_gb': None,
             'cleanup_interval_hours': 6,
+            'missing_backfill_hours': 4,
             'dry_run_mode': True,
             'auto_assign_new_series': False,
             'notifications_enabled': False,

--- a/templates/scheduler_admin.html
+++ b/templates/scheduler_admin.html
@@ -65,7 +65,20 @@
                                 </div>
                             </div>
                             
-                            <div class="col-md-9">
+                            <div class="col-md-3">
+                                <div class="mb-3">
+                                    <label for="missingBackfillHours" class="form-label">
+                                        Missing Episode Backfill (hours)
+                                    </label>
+                                    <input type="number" class="form-control" id="missingBackfillHours"
+                                           name="missing_backfill_hours" min="0" max="168" value="4">
+                                    <small class="form-text text-muted">
+                                        Search aired, monitored, missing episodes of managed series (0 = disabled)
+                                    </small>
+                                </div>
+                            </div>
+
+                            <div class="col-md-6">
                                 <label class="form-label">Cleanup Options</label>
                                 
                                 <div class="form-check form-switch mb-2">
@@ -309,8 +322,11 @@ async function loadGlobalSettings() {
             // Populate form
             document.getElementById('globalStorageGate').value = 
                 globalSettings.global_storage_min_gb || '';
-            document.getElementById('cleanupInterval').value = 
+            document.getElementById('cleanupInterval').value =
                 globalSettings.cleanup_interval_hours || 6;
+            document.getElementById('missingBackfillHours').value =
+                (globalSettings.missing_backfill_hours !== undefined && globalSettings.missing_backfill_hours !== null)
+                    ? globalSettings.missing_backfill_hours : 4;
             document.getElementById('dryRunMode').checked = 
                 globalSettings.dry_run_mode || false;
             document.getElementById('autoAssignNewSeries').checked = 
@@ -347,6 +363,7 @@ async function saveGlobalSettings(event) {
     const settings = {
         global_storage_min_gb: formData.get('global_storage_min_gb') || null,
         cleanup_interval_hours: parseInt(formData.get('cleanup_interval_hours')) || 6,
+        missing_backfill_hours: formData.get('missing_backfill_hours') === '' ? 4 : (parseFloat(formData.get('missing_backfill_hours')) || 0),
         dry_run_mode: formData.has('dry_run_mode'),
         auto_assign_new_series: formData.has('auto_assign_new_series'),
         

--- a/templates/scheduler_admin.html
+++ b/templates/scheduler_admin.html
@@ -78,7 +78,20 @@
                                 </div>
                             </div>
 
-                            <div class="col-md-6">
+                            <div class="col-md-3">
+                                <div class="mb-3">
+                                    <label for="missingBackfillMaxAge" class="form-label">
+                                        Backfill Max Age (days)
+                                    </label>
+                                    <input type="number" class="form-control" id="missingBackfillMaxAge"
+                                           name="missing_backfill_max_age_days" min="0" max="365" value="7">
+                                    <small class="form-text text-muted">
+                                        Only backfill episodes aired within this window (0 = no cap)
+                                    </small>
+                                </div>
+                            </div>
+
+                            <div class="col-md-3">
                                 <label class="form-label">Cleanup Options</label>
                                 
                                 <div class="form-check form-switch mb-2">
@@ -327,6 +340,9 @@ async function loadGlobalSettings() {
             document.getElementById('missingBackfillHours').value =
                 (globalSettings.missing_backfill_hours !== undefined && globalSettings.missing_backfill_hours !== null)
                     ? globalSettings.missing_backfill_hours : 4;
+            document.getElementById('missingBackfillMaxAge').value =
+                (globalSettings.missing_backfill_max_age_days !== undefined && globalSettings.missing_backfill_max_age_days !== null)
+                    ? globalSettings.missing_backfill_max_age_days : 7;
             document.getElementById('dryRunMode').checked = 
                 globalSettings.dry_run_mode || false;
             document.getElementById('autoAssignNewSeries').checked = 
@@ -364,6 +380,7 @@ async function saveGlobalSettings(event) {
         global_storage_min_gb: formData.get('global_storage_min_gb') || null,
         cleanup_interval_hours: parseInt(formData.get('cleanup_interval_hours')) || 6,
         missing_backfill_hours: formData.get('missing_backfill_hours') === '' ? 4 : (parseFloat(formData.get('missing_backfill_hours')) || 0),
+        missing_backfill_max_age_days: formData.get('missing_backfill_max_age_days') === '' ? 7 : (parseFloat(formData.get('missing_backfill_max_age_days')) || 0),
         dry_run_mode: formData.has('dry_run_mode'),
         auto_assign_new_series: formData.has('auto_assign_new_series'),
         

--- a/webhooks.py
+++ b/webhooks.py
@@ -192,23 +192,13 @@ def process_sonarr_webhook():
                 if default_rule_name not in config['rules']:
                     return jsonify({"status": "error", "message": f"Default rule '{default_rule_name}' missing"}), 500
 
-                series_id_str = str(series_id)
-                target_rule = config['rules'][default_rule_name]
-                target_rule.setdefault('series', {})
-                series_dict = target_rule['series']
-
-                if series_id_str not in series_dict:
-                    from episeerr import save_config
-                    series_dict[series_id_str] = {'activity_date': None}
-                    save_config(config)
-                    try:
-                        episeerr_utils.sync_rule_tag_to_sonarr(series_id, default_rule_name)
-                    except Exception as e:
-                        current_app.logger.error(f"Auto-assign tag sync failed: {e}")
-                    current_app.logger.info(f"Auto-assigned to default rule '{default_rule_name}'")
-
-                # Set assigned_rule and continue to processing
+                # Set assigned_rule and continue to processing. The assignment
+                # is persisted by the common "Add to config + sync tag" block
+                # further down, which runs AFTER unmonitor_series() - persisting
+                # here (before unmonitoring) could leave a fully-monitored
+                # series assigned to a rule if unmonitoring fails.
                 assigned_rule = default_rule_name
+                current_app.logger.info(f"Auto-assigning to default rule '{default_rule_name}'")
             else:
                 # ONLY return if auto-assign is OFF
                 current_app.logger.info("No episeerr tags + auto-assign off → no action")
@@ -218,7 +208,15 @@ def process_sonarr_webhook():
         # We have action → unmonitor + cleanup tags + cancel downloads
         # ────────────────────────────────────────────────────────────────
         current_app.logger.info(f"Unmonitoring episodes for {series_title}")
-        episeerr_utils.unmonitor_series(series_id, headers)
+        if not episeerr_utils.unmonitor_series(series_id, headers):
+            # Do NOT persist a rule assignment for a series that is still fully
+            # monitored: a later search (rule processing or the missing-episode
+            # backfill) would grab the entire aired season/back catalog.
+            current_app.logger.error(
+                f"Failed to unmonitor {series_title} - aborting webhook processing "
+                f"so the rule assignment is not persisted while all episodes are still monitored"
+            )
+            return jsonify({"status": "error", "message": "Failed to unmonitor series; not persisting rule assignment"}), 502
 
         # Remove ONLY episeerr_select/episeerr_default/episeerr_delay (keep rule tags)
         updated_tags = []


### PR DESCRIPTION
Fixes #79

### The gap

For rule-managed series, Sonarr's automatic (RSS) grabs are permanently held by the Episeerr delay profile (the rule-marker tag stays on the series, and the delay profile is bound to the control tags). Episodes only download because Episeerr's `EpisodeSearch` commands are user-invoked searches that bypass delay profiles — and those fire only on watch events. A user who is caught up on a currently-airing show never gets newly aired episodes: the episode is monitored, RSS is delay-blocked, and no watch event ever re-triggers a search. Full mechanism and a live reproduction in #79.

### The fix

A periodic **missing-episode backfill** hooked into the existing `OCDarrScheduler` loop (same 10-minute tick used by cleanup):

- Every `missing_backfill_hours` (global setting, **default 4**, `0` = disabled; the `MISSING_BACKFILL_HOURS` env var sets the default), it walks `config['rules']` and, for every assigned series, fetches its episodes from Sonarr.
- Episodes that are **monitored**, have **no file**, **aired at least 30 minutes ago**, and **aired within the last `missing_backfill_max_age_days` days** (default 7, `0` = no cap, `MISSING_BACKFILL_MAX_AGE_DAYS` env sets the default) get a batched `EpisodeSearch` per series (reuses the existing `search_episodes()` helper).
- **Only rules with action `search`** are searched — for `monitor` rules the user explicitly chose not to auto-search, so the backfill leaves them alone.
- **Future episodes are never searched**, so adding a series to a rule still cannot grab upcoming seasons. For *recent aired* episodes the backfill intentionally bypasses the delay-profile hold — that is the point of the feature.
- The **recency cap** keeps the backfill scoped to "stay current on airing shows": episodes whose files Episeerr's own cleanup deleted (cleanup deletes files but leaves them monitored), or the aired back catalog of a fully-monitored series added to a rule via the UI, fall outside the window and are not re-searched.
- Defensive: Sonarr unreachable / bad responses / config errors are logged and skipped; the scheduler thread can't die from the backfill.
- The backfill ignores global **dry-run mode** by design: dry run gates deletions, and the backfill never deletes anything. Disable it via interval `0` (documented in the README).

### Changes

- `episeerr_utils.py` — new `select_missing_aired_episodes()` (pure selection, testable) + `run_missing_episode_backfill()` (walks rules, searches per series).
- `episeerr.py` — scheduler wiring (`last_missing_backfill`, intervals from global settings with env-defaults), backfill state in scheduler status, and both settings handled + preserved in the global-settings POST (the handler rebuilds the dict, so the keys had to be carried).
- `media_processor.py` — `missing_backfill_hours: 4` and `missing_backfill_max_age_days: 7` added to default global settings.
- `templates/scheduler_admin.html` — "Missing Episode Backfill (hours)" and "Backfill Max Age (days)" inputs, wired into load/save.
- `README.md` — "Missing Episode Backfill" section under Features Explained.
- `webhooks.py` (separate commit) — the series-add webhook now persists an auto-assigned rule only **after** `unmonitor_series()` succeeds, and aborts without persisting when unmonitoring fails. Included in this PR because the backfill turns that stuck state (fully-monitored series assigned to a rule) from mostly inert into one that deterministically triggers searches.

### Review findings addressed

An independent review of the first revision requested changes; addressed in `f0e54d9` and `7df854f`:

1. **Redownload churn with Episeerr's own cleanup** (major): cleanup deletes episode *files* but leaves episodes monitored, so the unbounded backfill would have re-downloaded them forever on grace/dormant rules with action `search`. Fixed by the `missing_backfill_max_age_days` recency cap (default 7 days).
2. **Mass search after UI rule assignment** (major): assigning an existing fully-monitored series to a rule would have back-filled its entire aired catalog. Also fixed by the recency cap.
3. **Auto-assign ordering / unmonitor-failure leak** (minor): fixed in `webhooks.py` as described above.
4. **Deprecated `datetime.utcnow()`** → timezone-aware `datetime.now(timezone.utc)` + `astimezone(timezone.utc)` parsing.
5. **Docs**: dry-run behavior documented; delay-profile wording corrected (the hold stays for future episodes; recent aired episodes are searched deliberately).

### Testing (local live deployment)

- Built the image and ran it against a live Sonarr with one managed series ("Lucky (2026)", caught up: E2 has file, E3/E4 monitored + missing but airing in the future).
- Scheduled run fires in the container and logs `✓ Missing episode backfill complete: nothing to search (1 managed series checked)` — confirming E3/E4 are seen but **not** searched (air-date guard).
- Unit-style test of `select_missing_aired_episodes()` inside the container against a fabricated episode list: selects aired+monitored+missing inside the window (incl. one 40 min past air and one just inside the 7-day boundary), skips future, skips aired-<30-min buffer, skips hasFile, skips unmonitored, skips TBA (no `airDateUtc`), skips aired-8-days-ago under the default cap, and re-includes it with the cap disabled (`max_age_days=0`). All assertions pass.
- Settings round-trip verified: both values survive a Scheduler Admin save (POST handler preserves/serializes them) and appear in `/api/scheduler-status`.
