### PR TITLE
fix: prefetch next episode on playback start instead of ignoring it (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,9 @@ If you use the `+` activation modifier (`s*e1+`, `e1+`, etc.) and want the hold 
    ```
 4. **Save**
 
-> For non-held series (no `+` modifier), playback start events are silently ignored — no risk of double-processing.
-> Do not add `"notification_type"` to the "Watched" agent's template — leave it out there, since a hardcoded `"playback start"` on the Watched agent would make watched events get ignored too.
+> Playback start runs in **prefetch-only** mode: your get-count is applied, so the next episode is staged as soon as you start watching. Everything triggered by *finishing* an episode — keep-window deletion, finale keep-release, sequential season advance, series-ended unmonitor — is deferred to the "Watched" event, so nothing is ever deleted while you're mid-episode. Held series (`+` modifier) are the exception: their activation episode releases the hold and processes fully on play start, as before.
+> Configuring the Playback Start agent is optional. Without it, everything still works off the "Watched" event alone — you just get the next episode after finishing rather than at the start.
+> Do not add `"notification_type"` to the "Watched" agent's template — leave it out there, since a hardcoded `"playback start"` on the Watched agent would make watched events prefetch-only and never clean up.
 
 In Tautulli → Settings → General, set **TV Episode Watched Percent** between 50–95% (recommended: 80%).
 

--- a/integrations/tautulli.py
+++ b/integrations/tautulli.py
@@ -32,19 +32,24 @@ logger = logging.getLogger(__name__)
 
 def process_watch_event(data: dict) -> dict:
     """
-    Handle a Tautulli webhook payload — "watched", or "playback start" for
-    held-activation series (e.g. always_have's e1+ modifier).
+    Handle a Tautulli webhook payload — "watched", or "playback start".
 
-    A "playback start" event is only ever treated as a watch: for every other
-    series it's a no-op, since playback starting is not playback finishing —
-    processing it as a full watched event would fire keep-window and
-    finale-release cleanup on an episode someone just started playing, which
-    is exactly the "episode you're mid-watch on gets deleted" bug (#62). The
-    only reason to act on it at all is to release a held e1+-style hold,
-    which is explicitly designed to trigger on playback start rather than
-    completion. This guard lives here (not in a route handler) so it applies
-    to every caller, including the legacy /webhook backward-compatibility
-    route in webhooks.py, which delegates straight to this function.
+    A "playback start" event is not a watch: processing it as a full watched
+    event would fire keep-window and finale-release cleanup on an episode
+    someone just started playing, which is exactly the "episode you're
+    mid-watch on gets deleted" bug (#62). It is not a no-op either — staging
+    the next episode as soon as you start one is the feature #62 asked for.
+
+    So playback start runs in prefetch-only mode: the get_count fetch runs,
+    every completion-triggered step (keep-window deletion, finale release,
+    sequential advance, series-ended unmonitor) is suppressed until the real
+    watched event arrives. Held e1+-style series are the one exception — an
+    activation episode releases its hold and processes fully, since that hold
+    is designed to release on playback start rather than completion.
+
+    This lives here (not in a route handler) so it applies to every caller,
+    including the legacy /webhook backward-compatibility route in webhooks.py,
+    which delegates straight to this function.
 
     Extracts series/episode identifiers, performs Sonarr tag-sync and
     drift correction, then spawns media_processor.py to process the
@@ -56,6 +61,7 @@ def process_watch_event(data: dict) -> dict:
     """
     try:
         notification_type = (data.get('notification_type') or '').strip().lower()
+        prefetch_only = False
 
         if notification_type == 'playback start':
             ps_series_title  = (data.get('plex_title') or data.get('server_title') or '').strip()
@@ -70,19 +76,20 @@ def process_watch_event(data: dict) -> dict:
             is_activation, _ = is_held_activation_episode(
                 ps_series_title, int(ps_season_number), int(ps_episode_number)
             )
-            if not is_activation:
+            if is_activation:
                 logger.info(
-                    f"[Tautulli] Playback start for non-held series "
-                    f"({ps_series_title} S{ps_season_number}E{ps_episode_number}) — ignored"
+                    f"[Tautulli] Held activation: {ps_series_title} "
+                    f"S{ps_season_number}E{ps_episode_number} — releasing hold on play start"
                 )
-                return {'status': 'success', 'message': 'Playback start noted'}
-
-            logger.info(
-                f"[Tautulli] Held activation: {ps_series_title} "
-                f"S{ps_season_number}E{ps_episode_number} — releasing hold on play start"
-            )
-            # Fall through to normal processing below — activation is
-            # designed to release on playback start, same as a watched event.
+                # Full processing — the hold is designed to release on playback
+                # start, same as a watched event.
+            else:
+                prefetch_only = True
+                logger.info(
+                    f"[Tautulli] Playback start: {ps_series_title} "
+                    f"S{ps_season_number}E{ps_episode_number} — prefetch only "
+                    f"(cleanup deferred to watched event)"
+                )
 
         # {show_name} is TV-only in Tautulli; movies send it empty — fall back to {title}
         series_title   = (data.get('plex_title') or data.get('plex_movie_title') or
@@ -101,6 +108,16 @@ def process_watch_event(data: dict) -> dict:
         is_movie = (media_type_field == 'movie') or (_absent(season_number) and _absent(episode_number))
 
         if is_movie:
+            # A movie has no "next episode" to stage, so prefetch-only has
+            # nothing to do — and recording it watched on playback start would
+            # be wrong. Wait for the watched event.
+            if prefetch_only:
+                logger.info(
+                    f"[Tautulli] Playback start for movie '{series_title}' — "
+                    f"ignored (nothing to prefetch)"
+                )
+                return {'status': 'success', 'message': 'Playback start noted'}
+
             logger.info(f"[Tautulli] Movie watched: '{series_title}' (tmdb={themoviedb_id or 'unknown'})")
             if themoviedb_id:
                 try:
@@ -147,6 +164,7 @@ def process_watch_event(data: dict) -> dict:
             "sonarr_series_id": series_id,
             "rule":            final_rule,
             "source":          "tautulli",
+            "prefetch_only":   prefetch_only,
         }
 
         temp_path = os.path.join(temp_dir, f'data_from_server_{os.urandom(4).hex()}.json')
@@ -164,10 +182,12 @@ def process_watch_event(data: dict) -> dict:
                 f"[Tautulli] media_processor failed (rc={result.returncode}): {result.stderr}"
             )
         else:
-            logger.info(f"[Tautulli] Processed {series_title} S{season_number}E{episode_number}")
+            action = "Prefetched for" if prefetch_only else "Processed"
+            logger.info(f"[Tautulli] {action} {series_title} S{season_number}E{episode_number}")
 
-        # Update Plex Watchlist watched status for TV
-        if themoviedb_id:
+        # Update Plex Watchlist watched status for TV — not on playback start,
+        # the episode hasn't been watched yet.
+        if themoviedb_id and not prefetch_only:
             try:
                 from integrations.plex import PlexIntegration
                 PlexIntegration().mark_item_watched(str(themoviedb_id), 'tv')
@@ -360,7 +380,9 @@ class TautulliIntegration(ServiceIntegration):
             Configure in Tautulli:
               Settings → Notification Agents → Webhook
               Trigger: Watched  (primary)
-              Trigger: Playback Start  (optional — enables held activation)
+              Trigger: Playback Start  (optional — stages the next episode
+                                        as soon as you start watching, and
+                                        enables held activation)
               URL: http://<episeerr-host>:5002/api/integration/tautulli/webhook
 
             For playback start support, add a hardcoded literal
@@ -369,6 +391,11 @@ class TautulliIntegration(ServiceIntegration):
             {notification_type} placeholder, so a template using braces
             there sends back the literal unsubstituted text and this guard
             never fires. Leave the field out of the Watched agent's template.
+
+            Playback start runs prefetch-only: get-count applies, but every
+            completion-triggered step (keep-window deletion, finale release,
+            sequential advance, series-ended unmonitor) waits for the Watched
+            event, so nothing is deleted mid-episode.
             """
             logger.info("[Tautulli] Webhook received")
             data = request.get_json(silent=True) or {}

--- a/media_processor.py
+++ b/media_processor.py
@@ -494,16 +494,21 @@ def get_server_activity():
             season_number = data.get('plex_season_num')
             episode_number = data.get('plex_ep_num')
         
+        # Playback-start events set this: stage the next episode, but leave
+        # every completion-triggered step to the later watched event.
+        prefetch_only = bool(data.get('prefetch_only', False))
+
         if all([series_title, season_number, episode_number]):
-            return series_title, int(season_number), int(episode_number), thetvdb_id, themoviedb_id
-            
+            return (series_title, int(season_number), int(episode_number),
+                    thetvdb_id, themoviedb_id, prefetch_only)
+
         logger.error(f"Required data fields not found in {filepath}")
-        return None, None, None, None, None
-        
+        return None, None, None, None, None, False
+
     except Exception as e:
         logger.error(f"Failed to read or parse data from server webhook: {str(e)}")
-    
-    return None, None, None, None, None
+
+    return None, None, None, None, None, False
 
 def better_partial_match(webhook_title, sonarr_title):
     webhook_clean = webhook_title.lower().strip()
@@ -1196,7 +1201,8 @@ def _find_episodes_in_keep_window(all_episodes, keep_type, keep_count, last_watc
     ]
 
 
-def process_episodes_for_webhook(series_id, season_number, episode_number, rule, series_title=None):
+def process_episodes_for_webhook(series_id, season_number, episode_number, rule, series_title=None,
+                                 prefetch_only=False):
     """
     Clean webhook processing - ONLY handles real-time episode management.
     Grace cleanup happens separately during scheduled cleanup (every 6 hours).
@@ -1210,6 +1216,15 @@ def process_episodes_for_webhook(series_id, season_number, episode_number, rule,
     Sequential mode (eN+ without s prefix):
       After normal processing, if the watched episode is the season finale the
       next season's activation episode is grabbed and set to held.
+
+    Prefetch-only mode (playback start):
+      Starting an episode is not finishing it, so a playback-start event runs
+      the get_count fetch (staging the next episode, issue #62) and nothing
+      else.  Every step whose trigger is *completion* is suppressed: keep-window
+      deletion, finale keep-release, sequential season advance, series-ended
+      unmonitor, and unmonitoring the episode currently being played.  Those all
+      run later on the real watched event.  This is what keeps the "episode you
+      are mid-watch on gets deleted" bug fixed while still allowing the prefetch.
     """
     try:
         logger.info(f"Processing webhook for series {series_id}: S{season_number}E{episode_number}")
@@ -1273,7 +1288,9 @@ def process_episodes_for_webhook(series_id, season_number, episode_number, rule,
             logger.error(f"Could not find current episode S{season_number}E{episode_number}")
             return
 
-        if not rule.get('monitor_watched', True):
+        # Unmonitoring the current episode means "done with it" — on playback
+        # start it is still being played, so leave it monitored until watched.
+        if not rule.get('monitor_watched', True) and not prefetch_only:
             unmonitor_episodes([current_episode['id']])
 
         if not skip_rule_processing:
@@ -1288,6 +1305,13 @@ def process_episodes_for_webhook(series_id, season_number, episode_number, rule,
                     series_id, series_title, get_type
                 )
                 logger.info(f"Processed {len(next_episode_ids)} next episodes")
+
+            if prefetch_only:
+                logger.info(
+                    f"Prefetch-only (playback start) for {series_title or series_id} "
+                    f"S{season_number}E{episode_number} — skipping keep-window cleanup"
+                )
+                return
 
             # IMMEDIATE DELETION: Episodes leaving keep block (real-time cleanup)
             episodes_leaving_keep_block = find_episodes_leaving_keep_block(
@@ -1331,7 +1355,7 @@ def process_episodes_for_webhook(series_id, season_number, episode_number, rule,
                     )
 
         # ── Season finale: release keep protection when no next season exists ─
-        if rule.get('release_keep_on_finale', False) and not skip_rule_processing:
+        if rule.get('release_keep_on_finale', False) and not skip_rule_processing and not prefetch_only:
             season_eps = sorted(
                 [ep for ep in all_episodes
                  if ep['seasonNumber'] == season_number and ep['seasonNumber'] > 0],
@@ -1391,13 +1415,13 @@ def process_episodes_for_webhook(series_id, season_number, episode_number, rule,
 
         # ── Sequential mode: advance to next season on finale ──────────────
         if (parsed_ah and parsed_ah['has_plus'] and parsed_ah['is_sequential']
-                and not skip_rule_processing):
+                and not skip_rule_processing and not prefetch_only):
             _advance_sequential_if_finale(
                 series_id, season_number, episode_number, rule, series_title, all_episodes
             )
 
         # ── Series ended: unmonitor season + series (opt-in) ────────────────
-        if rule.get('unmonitor_on_series_ended', False) and not skip_rule_processing:
+        if rule.get('unmonitor_on_series_ended', False) and not skip_rule_processing and not prefetch_only:
             _unmonitor_if_series_ended(
                 series_id, season_number, series_title
             )
@@ -3227,7 +3251,7 @@ def main():
         return False
 
     # Check if this is a webhook call (has recent webhook data)
-    series_name, season_number, episode_number, thetvdb_id, themoviedb_id = get_server_activity()
+    series_name, season_number, episode_number, thetvdb_id, themoviedb_id, prefetch_only = get_server_activity()
 
     # ONLY process as webhook if this was called BY a webhook (not manual cleanup)
     # Add a flag or check timestamp to distinguish
@@ -3245,6 +3269,7 @@ def main():
 
     if series_name and is_recent_webhook:
         # Webhook mode - process the episode that was just watched
+        # (or just started, when the integration flagged it prefetch-only)
         series_id = get_series_id(series_name, thetvdb_id, themoviedb_id)
         if series_id:
             config = load_config()
@@ -3254,7 +3279,8 @@ def main():
 
             if config_rule:
                 rule = config['rules'][config_rule]
-                process_episodes_for_webhook(series_id, season_number, episode_number, rule, series_name)
+                process_episodes_for_webhook(series_id, season_number, episode_number, rule, series_name,
+                                             prefetch_only=prefetch_only)
             else:
                 update_activity_date(series_id, season_number, episode_number)
             return True

--- a/test_prefetch_on_playback_start.py
+++ b/test_prefetch_on_playback_start.py
@@ -1,0 +1,147 @@
+"""
+Regression test for prefetch-on-playback-start (issue #62).
+
+Playback start must stage the next episode but must NOT run any
+completion-triggered step (keep-window deletion, finale release, sequential
+advance, series-ended unmonitor, unmonitor-current). The watched event must
+still do all of it.
+
+Runs standalone: python test_prefetch_on_playback_start.py
+"""
+import sys
+import types
+from unittest import mock
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_media_processor():
+    """Import media_processor with its external deps stubbed out."""
+    _stub_module('dotenv', load_dotenv=lambda *a, **k: None)
+    _stub_module('requests',
+                 get=mock.MagicMock(), put=mock.MagicMock(),
+                 post=mock.MagicMock(), delete=mock.MagicMock(),
+                 Session=mock.MagicMock())
+    _stub_module('pending_deletions', PendingDeletions=mock.MagicMock())
+    _stub_module('servarr_utils')
+    _stub_module('episeerr',
+                 normalize_url=lambda u: (u or '').rstrip('/'),
+                 load_config=lambda: {'rules': {}},
+                 save_config=lambda c: None,
+                 load_global_settings=lambda: {})
+    _stub_module('episeerr_utils',
+                 reconcile_series_drift=lambda sid, cfg, series_data=None: (None, False),
+                 http=mock.MagicMock())
+    _stub_module('logging_config', main_logger=mock.MagicMock())
+    _stub_module('settings_db',
+                 get_sonarr_config=lambda: {'url': 'http://sonarr:8989', 'api_key': 'x'},
+                 get_service=lambda *a, **k: None)
+    import media_processor
+    return media_processor
+
+
+mp = _load_media_processor()
+
+RULE = {
+    'get_type': 'episodes', 'get_count': 1,
+    'keep_type': 'episodes', 'keep_count': 1,
+    'action_option': 'search',
+    'monitor_watched': False,          # would unmonitor the current episode
+    'release_keep_on_finale': True,    # destructive finale path enabled
+    'unmonitor_on_series_ended': True, # destructive series-ended path enabled
+    'always_have': '',
+}
+
+EPISODES = [
+    {'id': 1, 'seasonNumber': 3, 'episodeNumber': 2, 'hasFile': True,  'episodeFileId': 11},
+    {'id': 2, 'seasonNumber': 3, 'episodeNumber': 3, 'hasFile': True,  'episodeFileId': 12},
+    {'id': 3, 'seasonNumber': 3, 'episodeNumber': 4, 'hasFile': True,  'episodeFileId': 13},
+    {'id': 4, 'seasonNumber': 3, 'episodeNumber': 5, 'hasFile': False, 'episodeFileId': None},
+]
+
+
+def run(prefetch_only):
+    """Invoke the webhook processor for S3E4 and capture what it did."""
+    calls = {}
+    with mock.patch.object(mp, 'fetch_all_episodes', return_value=list(EPISODES)), \
+         mock.patch.object(mp, 'update_activity_date') as activity, \
+         mock.patch.object(mp, 'unmonitor_episodes') as unmonitor, \
+         mock.patch.object(mp, 'monitor_or_search_episodes') as prefetch, \
+         mock.patch.object(mp, 'fetch_next_episodes_dropdown', return_value=[4]), \
+         mock.patch.object(mp, 'delete_episodes_immediately') as delete, \
+         mock.patch.object(mp, '_advance_sequential_if_finale') as advance, \
+         mock.patch.object(mp, '_unmonitor_if_series_ended') as ended, \
+         mock.patch.object(mp, 'is_anchor_episode', return_value=False), \
+         mock.patch.object(mp, 'load_config', return_value={'rules': {}}), \
+         mock.patch.object(mp, '_find_rule_name_for_series', return_value='testrule'):
+        mp.process_episodes_for_webhook(
+            series_id=42, season_number=3, episode_number=4,
+            rule=dict(RULE), series_title='Test Show',
+            prefetch_only=prefetch_only,
+        )
+        calls['activity'] = activity.call_count
+        calls['unmonitor_current'] = unmonitor.call_count
+        calls['prefetch'] = prefetch.call_count
+        calls['delete'] = delete.call_count
+        calls['advance'] = advance.call_count
+        calls['series_ended'] = ended.call_count
+    return calls
+
+
+def check_payload_parsing():
+    """get_server_activity must surface the prefetch_only flag from the payload."""
+    import json as _json
+
+    base = {
+        'server_title': 'Test Show', 'server_season_num': 3, 'server_ep_num': 4,
+        'thetvdb_id': '448463', 'themoviedb_id': None,
+    }
+
+    def parse(payload):
+        with mock.patch.object(mp.os.path, 'exists', return_value=True), \
+             mock.patch.object(mp, 'open', mock.mock_open(read_data=_json.dumps(payload)), create=True):
+            return mp.get_server_activity()
+
+    # Flag present and true → prefetch_only True
+    assert parse({**base, 'prefetch_only': True})[5] is True, "prefetch_only=True must parse"
+    # Flag present and false → full processing
+    assert parse({**base, 'prefetch_only': False})[5] is False, "prefetch_only=False must parse"
+    # Flag absent (legacy /webhook route, older payloads) → full processing
+    assert parse(base)[5] is False, "absent prefetch_only must default to full processing"
+    print("payload parsing: prefetch_only true/false/absent OK")
+
+
+def main():
+    check_payload_parsing()
+
+    start = run(prefetch_only=True)
+    watched = run(prefetch_only=False)
+
+    # Playback start: stage the next episode, touch nothing destructive.
+    assert start['prefetch'] == 1, f"playback start must prefetch: {start}"
+    assert start['delete'] == 0, f"playback start must NOT delete: {start}"
+    assert start['unmonitor_current'] == 0, f"playback start must NOT unmonitor current ep: {start}"
+    assert start['advance'] == 0, f"playback start must NOT advance sequential: {start}"
+    assert start['series_ended'] == 0, f"playback start must NOT unmonitor ended series: {start}"
+    # Activity date still updates, so an actively-watched series is not grace-cleaned.
+    assert start['activity'] == 1, f"playback start must still update activity date: {start}"
+
+    # Watched event: unchanged behavior, cleanup still runs.
+    assert watched['prefetch'] == 1, f"watched must prefetch: {watched}"
+    assert watched['delete'] == 1, f"watched must still delete keep-block: {watched}"
+    assert watched['unmonitor_current'] == 1, f"watched must unmonitor current ep: {watched}"
+    assert watched['series_ended'] == 1, f"watched must run series-ended check: {watched}"
+
+    print("playback start :", start)
+    print("watched        :", watched)
+    print("OK - prefetch runs on start, cleanup deferred to watched")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Playback start currently stages nothing for any series without an `e1+` hold — the next episode isn't fetched until the watched event fires. This restores the behavior [#62](https://github.com/Vansmak/episeerr/issues/62) originally asked for ("trigger the second episode download immediately once the user begins watching episode one") **without** reintroducing the mid-watch deletion bug that the same issue's fix addressed.

## What happened

Two separate things live in #62:

1. **The feature request** — start an episode, get the next one staged right away.
2. **The bug** — full watched-processing running on playback start deleted the episode being played.

The fix in v3.7.18 (per [this comment](https://github.com/Vansmak/episeerr/issues/62#issuecomment-5075256822)) correctly made the guard *fire* — `{notification_type}` was never a real Tautulli placeholder, so the v3.7.16 guard had never actually worked. But the now-working guard returns early for everything that isn't a held activation:

https://github.com/Vansmak/episeerr/blob/main/integrations/tautulli.py#L73-L78

```python
if not is_activation:
    logger.info(
        f"[Tautulli] Playback start for non-held series "
        f"({ps_series_title} S{ps_season_number}E{ps_episode_number}) — ignored"
    )
    return {'status': 'success', 'message': 'Playback start noted'}
```

That suppressed the harmless prefetch along with the destructive cleanup. Fixing the bug switched the feature off.

## Reproduction

Observed on v3.8.0 with a normal (non-held) series. Playback start at `00:12:38`, watched at `00:57:45`. Series/user anonymized.

Tautulli sent both events successfully, to the same webhook, ~45 min apart:

```
00:12:38 - INFO :: Tautulli ActivityHandler :: Session N started by user <redacted> with ratingKey <redacted> (<Series> - <Episode Title>).
00:12:38 - INFO :: Tautulli Notifiers :: Sending Webhook notification...
00:12:38 - INFO :: Tautulli Notifiers :: Webhook notification sent.
00:57:45 - INFO :: Tautulli Notifiers :: Sending Webhook notification...
00:57:49 - INFO :: Tautulli Notifiers :: Webhook notification sent.
```

Episeerr ignored the first and acted only on the second:

```
00:12:38,106 - INFO - Received webhook on legacy /webhook route — delegating to Tautulli integration
00:12:38,251 - INFO - Found exact match: <Series>
00:12:38,251 - INFO - [Tautulli] Playback start for non-held series (<Series> S3E4) — ignored

00:57:45,402 - INFO - Received webhook on legacy /webhook route — delegating to Tautulli integration
00:57:45,534 - INFO - Found TVDB ID match: <Series> (TVDB: <redacted>)
00:57:49,817 - INFO - [Tautulli] Processed <Series> S3E4
```

Sonarr only searched after the watched event — 45 minutes after playback began:

```
[Info] ReleaseSearchService: Searching indexers for [<Series> : S03E05]. 2 active indexers
[Info] Sabnzbd: Adding report [<release name>] to the queue.
[Info] DownloadService: Report sent to SABnzbd. Indexer <indexer> (Prowlarr). <release name>
```

Notifier config confirms both agents point at the same webhook, with `notification_type` correctly set as a hardcoded literal on Playback Start only, exactly as the README instructs:

```
   friendly_name: <Playback Start agent>
     agent_label: Webhook
         on_play: 1
      on_watched: 1
 notifier_config: {"hook": "http://episeerr:5002/webhook", "method": "POST"}

  on_play_body: { ..., "notification_type": "playback start" }
on_watched_body: { ... }        # no notification_type — per README
```

## The fix

Playback start now runs in **prefetch-only** mode rather than being dropped.

Runs on playback start:
- the `get_count` fetch (stages the next episode)
- `update_activity_date` — deliberately kept, so a series being actively watched can't look dormant to the 6-hourly grace cleanup

Deferred to the watched event:
- keep-window deletion ([`media_processor.py#L1302`](https://github.com/Vansmak/episeerr/blob/main/media_processor.py#L1302))
- finale keep-release (`release_keep_on_finale`)
- sequential season advance (`_advance_sequential_if_finale`)
- series-ended unmonitor (`unmonitor_on_series_ended`)
- unmonitoring the episode currently being played (`monitor_watched`)
- the Plex watchlist watched update

Held `e1+` series are unchanged — an activation episode still releases its hold and processes fully on play start.

Movies are skipped on playback start: nothing to prefetch, and recording a watch when playback merely started would be wrong.

## Notes for review

- **Backward compatible.** Payloads without `prefetch_only` (legacy `/webhook` route, older integrations, an unrecognized `notification_type`) parse as `False` and get full processing — unchanged behavior.
- **Double-fire is intentional and idempotent-in-effect.** Start and watched both prefetch the same episode ~45 min apart. `fetch_next_episodes_dropdown` doesn't filter on `hasFile`, so the watched event re-monitors and re-searches the same IDs. Sonarr treats a repeat search for an episode it already grabbed as a no-op, so this is the same duplicate-search behavior that already exists today when two watched events land for one episode. Happy to add a `hasFile` filter in `fetch_next_episodes_dropdown` if you'd prefer it suppressed — that's a separate concern from this change, so I left it out.
- **Jellyfin/Emby untouched.** They have their own `PlaybackStart`/`SessionStart` handling; this PR only changes the Tautulli path and the shared `process_episodes_for_webhook`.
- **Not addressed here:** integrations write `data_from_server_<rand>.json` and pass it as `argv[1]`, but `media_processor.py` never reads `sys.argv` and `get_server_activity()` opens the fixed `data_from_server.json`. On released v3.8.0 the Tautulli path writes the fixed name so this doesn't bite, but on `main` it looks like a live bug independent of this PR. Flagging rather than fixing, to keep the diff focused — say the word and I'll open a separate issue or PR.

## Testing

`test_prefetch_on_playback_start.py` asserts both directions with the Sonarr calls mocked:

```
payload parsing: prefetch_only true/false/absent OK
playback start : {'activity': 1, 'unmonitor_current': 0, 'prefetch': 1, 'delete': 0, 'advance': 0, 'series_ended': 0}
watched        : {'activity': 1, 'unmonitor_current': 1, 'prefetch': 1, 'delete': 1, 'advance': 0, 'series_ended': 1}
OK - prefetch runs on start, cleanup deferred to watched
```

Run with `python test_prefetch_on_playback_start.py` (stdlib only, no framework, no live Sonarr). It fails against the unpatched code.

### Live verification

Beyond the mocked test, this branch was built into an image, deployed to a running episeerr instance, and driven with real Tautulli-shaped webhooks against a live Sonarr 4.0.19. All three scenarios passed on the first round; no changes to the fix were needed. Series/user anonymized below.

**Playback start on a non-held series — prefetch fires, current episode untouched**

Webhook with `"notification_type": "playback start"` on S1E1 of a series with a `get_count: 1` / `action_option: search` rule:

- S1E2 flipped `monitored: false` → `monitored: true` — the prefetch ran, which is the behavior #62 asked for and which is a no-op on current `main`.
- S1E1 (the episode "being played") kept its existing monitored state and its file. Nothing was unmonitored, nothing was deleted.

**Held `e1+` activation on playback start — unchanged**

Webhook on the held S1 activation episode of a series with `activation_seasons: {"1": "held"}`:

- `activation_seasons["1"]` flipped `"held"` → `"active"` in `config.json`, exactly as before this change.
- The next episode was monitored — full processing ran, not prefetch-only. The carve-off for held activations is intact.

**Watched events — no regression**

Two pre-existing end-to-end cases covering the watched path were re-run unmodified against the patched image:

- Continuing series: series/season monitored state correctly left alone.
- Ended series: series and season correctly flip to unmonitored.

Both behave identically to the unpatched build, confirming the `prefetch_only=False` path is untouched.

Docs updated: the README note stating playback start is "silently ignored" for non-held series is no longer accurate, and the in-app Tautulli setup docstring now describes prefetch-only mode.
